### PR TITLE
Clear the actual screen

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -86,9 +86,11 @@ static GC create_gc(int line_width) {
   return gc;
 }
 
-static void clearScreen(GC gc, Window win, int width, int height) {
+static void clearScreen(GC gc, Window win) {
   XSetForeground(dpy, gc, WhitePixel(dpy, scr));
-  XFillRectangle(dpy, win, gc, 0, 0, width, height);
+  XWindowAttributes xwa;
+  XGetWindowAttributes(dpy, win, &xwa);
+  XFillRectangle(dpy, win, gc, 0, 0, xwa.width, xwa.height);
   XSetForeground(dpy, gc, BlackPixel(dpy, scr));  // Reset the foreground color
   XFlush(dpy);
 }
@@ -146,7 +148,7 @@ static void run(GC gc, Window __window_main__) {
         break;
       case KeyPress:
         if (XkbKeycodeToKeysym(dpy, ev.xkey.keycode, 0, 0) == XK_c) {
-          clearScreen(gc, __window_main__, WIDTH, HEIGHT);
+          clearScreen(gc, __window_main__);
         } else if (XkbKeycodeToKeysym(dpy, ev.xkey.keycode, 0, 0) ==
                    XK_Escape) {
           return;


### PR DESCRIPTION
Hi @cMardc,

this project is a great demonstration of how to use some X11 libraries!

I have noticed one issue, maybe specific to my tiling window manager ([dwm](https://dwm.suckless.org/)):

When the actual window/canvas is larger than the requested size (`WIDTH*HEIGHT`), it's possible to draw on the whole canvas but when I press the `C` key, only an area of `WIDTH*HEIGHT` is cleared:

![2024-10-06 17 23 31 1045x1026 Window](https://github.com/user-attachments/assets/3103e20a-5a7e-4330-b705-bc048683d94b)

This pull request fixes this by using the **actual** window size in `clearScreen`.